### PR TITLE
Rainbow colours in continuous streams

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2
+jobs:
+  test_stable:
+    docker:
+      - image: circleci/rust:latest
+    steps:
+      - checkout
+      - run: cargo test
+  test_1.31:
+    docker:
+      - image: circleci/rust:1.31
+    steps:
+      - checkout
+      - run: cargo test
+  build:
+    docker:
+      - image: circleci/rust:latest
+    steps:
+      - checkout
+      - run: cargo build --release
+workflows:
+  version: 2
+  test_and_build:
+    jobs:
+      - test_stable
+      - test_1.31
+      - build:
+          requires:
+            - test_stable
+            - test_1.31

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate structopt;
 extern crate rand;
 extern crate pancurses;
@@ -138,9 +137,9 @@ impl Matrix {
                     config.colour
                 };
                 // Draw the character
-                window.attron(COLOR_PAIR(mcolour as u64));
-                window.addch(self[i][j].val as u64);
-                window.attroff(COLOR_PAIR(mcolour as u64));
+                window.attron(COLOR_PAIR(mcolour as chtype));
+                window.addch(self[i][j].val as chtype);
+                window.attroff(COLOR_PAIR(mcolour as chtype));
             }
         }
         napms(config.update as i32 * 10);


### PR DESCRIPTION
This was an interesting read, thanks. I noticed your `--rainbow` implementation flickers quite a lot - this PR treats each stream as having a single continuous colour.

Still learning a lot about rust, so any thoughts/feedback welcome.

Before:
![rmatrix-rainbow-stream](https://user-images.githubusercontent.com/12255914/46046838-76b9d200-c11a-11e8-8845-f03990e8a6cb.png)

After:
![rmatrix-rainbow-stream](https://user-images.githubusercontent.com/12255914/46046813-6275d500-c11a-11e8-8b5d-a8e7bc48ee15.png)
