### PR TITLE
Fix compile error with pancurses and u32

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,9 +138,9 @@ impl Matrix {
                     config.colour
                 };
                 // Draw the character
-                window.attron(COLOR_PAIR(mcolour as u32));
-                window.addch(self[i][j].val as u32);
-                window.attroff(COLOR_PAIR(mcolour as u32));
+                window.attron(COLOR_PAIR(mcolour as u64));
+                window.addch(self[i][j].val as u64);
+                window.attroff(COLOR_PAIR(mcolour as u64));
             }
         }
         napms(config.update as i32 * 10);


### PR DESCRIPTION
Compiling master from a fresh install gives
```
error[E0308]: mismatched types
   --> src/lib.rs:141:42
    |
141 |                 window.attron(COLOR_PAIR(mcolour as usize));
    |                                          ^^^^^^^^^^^^^^^^ expected u64, found usize

error[E0277]: the trait bound `usize: pancurses::ToChtype` is not satisfied
   --> src/lib.rs:142:24
    |
142 |                 window.addch(self[i][j].val as usize);
    |                        ^^^^^ the trait `pancurses::ToChtype` is not implemented for `usize`

error[E0308]: mismatched types
   --> src/lib.rs:143:43
    |
143 |                 window.attroff(COLOR_PAIR(mcolour as usize));
    |                                           ^^^^^^^^^^^^^^^^ expected u64, found usize

error: aborting due to 3 previous errors

Some errors occurred: E0277, E0308.
For more information about an error, try `rustc --explain E0277`.
error: Could not compile `rmatrix`.
```

Casting to u64 instead of u32 fixes this.