### PR TITLE
Really fix compile error with pancurses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2
+jobs:
+  test_stable:
+    docker:
+      - image: circleci/rust:latest
+    steps:
+      - checkout
+      - run: cargo test
+  test_1.31:
+    docker:
+      - image: circleci/rust:1.31
+    steps:
+      - checkout
+      - run: cargo test
+  build:
+    docker:
+      - image: circleci/rust:latest
+    steps:
+      - checkout
+      - run: cargo build --release
+workflows:
+  version: 2
+  test_and_build:
+    jobs:
+      - test_stable
+      - test_1.31
+      - build:
+          requires:
+            - test_stable
+            - test_1.31

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate structopt;
 extern crate rand;
 extern crate pancurses;
@@ -138,9 +137,9 @@ impl Matrix {
                     config.colour
                 };
                 // Draw the character
-                window.attron(COLOR_PAIR(mcolour as u64));
-                window.addch(self[i][j].val as u64);
-                window.attroff(COLOR_PAIR(mcolour as u64));
+                window.attron(COLOR_PAIR(mcolour as chtype));
+                window.addch(self[i][j].val as chtype);
+                window.attroff(COLOR_PAIR(mcolour as chtype));
             }
         }
         napms(config.update as i32 * 10);


### PR DESCRIPTION
Pancurses `chtype` underlying integer type changes based on platform and architecture. Instead of trying to cast to a `u32` or `u64`, use the provided type alias `chtype`.

Also adds basic circleci config for compile checking.