### PR TITLE
feat: Implement pause functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # rmatrix
+
 Generates a 'Matrix'-like screen of falling characters in your terminal
 [![rmatrix](rmatrix.gif)](https://asciinema.org/a/IjJyH88BeocsHvJpKJYqvmnuT)
 
@@ -6,16 +7,20 @@ The original [`cmatrix`](https://github.com/abishekvashok/cmatrix) was written i
 The rust version is memory-safe, and doesn't crash so easily. Both versions have comparable performance, due to the underlying use of `ncurses`.
 
 ## Controls
-| Key | Control |
-| -- | -- |
-| 1-9 | Speed the letters fall (1 is fastest, 9 is slowest) |
-| Shift + 1-9 | Colour of the characters |
-| r | Rainbow mode |
+
+| Key         | Control                                             |
+| ----------- | --------------------------------------------------- |
+| 1-9         | Speed the letters fall (1 is fastest, 9 is slowest) |
+| Shift + 1-9 | Colour of the characters                            |
+| r           | Rainbow mode                                        |
+| p           | Pause the simulation                                |
 
 ## Installation
 
 ### cargo
+
 `cargo install r-matrix`
 
 ### Arch Linux
+
 `yay -S rmatrix`

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ extern crate signal_hook;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::{thread::sleep, time::Duration};
 
 use pancurses::*;
 use signal_hook::consts::signal::{SIGINT, SIGQUIT, SIGTERM, SIGWINCH};
@@ -51,8 +52,12 @@ fn main() {
             config.handle_keypress(c)
         }
 
-        // Update and redraw the board.
-        matrix.arrange(&config);
-        matrix.draw(&window, &config);
+        if !config.pause {
+            // Update and redraw the board.
+            matrix.arrange(&config);
+            matrix.draw(&window, &config);
+        } else {
+            sleep(Duration::from_millis(100))
+        }
     }
 }


### PR DESCRIPTION
When the `pause` value in `Config` is true, do not update or draw the matrix. Instead, sleep for 100ms so the CPU doesn't try to listen for keypresses with 100% CPU.